### PR TITLE
add cnetplot.compareClusterResult()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,9 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
 Version: 1.7.1
-Authors@R: person("Guangchuang", "Yu", email = "guangchuangyu@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781"))
+Authors@R: c(
+    person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
+    person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))
 Description: The 'enrichplot' package implements several visualization methods for interpreting functional enrichment results obtained from ORA or GSEA analysis.
              All the visualization methods are developed based on 'ggplot2' graphics.
 Depends: R (>= 3.4.0)

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -159,8 +159,10 @@ cnetplot.compareClusterResult <- function(x,
         V(g)$color <- "#B3B3B3"
         V(g)$color[1] <- "#E5C494"
         p <- ggraph(g, layout=layout, circular=circular) +
-            edge_layer +
-            geom_node_point(aes_(color=~I(color), size=~size))
+            edge_layer + theme_void() +
+            geom_node_point(aes_(color=~I(color), size=~size)) + 
+            scale_size(range=c(3, 8) * pie_scale) 
+            
         return(p)
     }
     
@@ -242,7 +244,7 @@ cnetplot.compareClusterResult <- function(x,
 
     ggraph(g, layout=layout, circular=circular) + 
     edge_layer + geom_node_point(aes_(color=~I(color), size=~size)) + labs(title= title) +
-    scale_size(range=c(3, 8) * pie_scale)
+    scale_size(range=c(3, 8) * pie_scale) + theme_void()
 }
 
 ##' Prepare the data for the pie plot

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -168,6 +168,15 @@ cnetplot.compareClusterResult <- function(x,
     ID_Cluster_mat2$radius[1:n] <- sizee
     x_loc1 <- min(ID_Cluster_mat2$x)
     y_loc1 <- min(ID_Cluster_mat2$y)
+    #node_label
+    if (node_label == "category") {
+        p$data$name[(n+1):nrow(p$data)] <- ""
+    } else if (node_label == "gene") {
+        p$data$name[1:n] <- ""
+    } else if (node_label == "none") {
+        p$data$name <- ""
+    }
+    
     if (!is.null(foldChange)) { 
         log_fc <- abs(foldChange)
         genes <- rownames(ID_Cluster_mat2)[(n+1):nrow(ID_Cluster_mat2)]

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -193,11 +193,12 @@ cnetplot.compareClusterResult <- function(x,
         return(p)
         
     }
-    p <- p + geom_scatterpie(aes_(x=~x,y=~y,r=~radius), data=ID_Cluster_mat2,
+    p + geom_scatterpie(aes_(x=~x,y=~y,r=~radius), data=ID_Cluster_mat2,
                                  cols=colnames(ID_Cluster_mat2)[1:(ncol(ID_Cluster_mat2)-3)],color=NA) +
-        coord_equal()+
-        geom_node_text(aes_(label=~name), repel=TRUE, size=2.5) + theme_void() +
-        labs(fill = "Cluster")
+    coord_equal()+
+    geom_node_text(aes_(label=~name), repel=TRUE, size=2.5) + theme_void() +
+    labs(fill = "Cluster")
+    
 
 }
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -161,7 +161,7 @@ cnetplot.compareClusterResult <- function(x,
         p <- ggraph(g, layout=layout, circular=circular) +
             edge_layer + theme_void() +
             geom_node_point(aes_(color=~I(color), size=~size)) + 
-            scale_size(range=c(3, 8) * pie_scale) 
+            scale_size(range=c(3, 8) * pie_scale) + theme(legend.position="none") 
             
         return(p)
     }
@@ -244,7 +244,7 @@ cnetplot.compareClusterResult <- function(x,
 
     ggraph(g, layout=layout, circular=circular) + 
     edge_layer + geom_node_point(aes_(color=~I(color), size=~size)) + labs(title= title) +
-    scale_size(range=c(3, 8) * pie_scale) + theme_void()
+    scale_size(range=c(3, 8) * pie_scale) + theme_void() + theme(legend.position="none") 
 }
 
 ##' Prepare the data for the pie plot

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -159,11 +159,12 @@ cnetplot.compareClusterResult <- function(x,
         V(g)$color <- "#B3B3B3"
         V(g)$color[1] <- "#E5C494"
         title <- y$Cluster 
-        p <- ggraph(g, layout=layout, circular=circular) +
-            edge_layer + theme_void() +
+        p <- ggraph(g, layout=layout, circular=circular)
+        p <- p + edge_layer + theme_void() +
             geom_node_point(aes_(color=~I(color), size=~size)) + 
             labs(title= title) +
-            scale_size(range=c(3, 8) * pie_scale) + theme(legend.position="none") 
+            scale_size(range=c(3, 8) * pie_scale) + theme(legend.position="none")+
+            geom_node_text(aes_(label=~name), data = p$data)            
             
         return(p)
     }
@@ -244,8 +245,9 @@ cnetplot.compareClusterResult <- function(x,
     V(g)$color <- "#B3B3B3"
     V(g)$color[1:n] <- "#E5C494"
 
-    ggraph(g, layout=layout, circular=circular) + 
-    edge_layer + geom_node_point(aes_(color=~I(color), size=~size)) + labs(title= title) +
+    p <- ggraph(g, layout=layout, circular=circular)     
+    p + edge_layer + geom_node_point(aes_(color=~I(color), size=~size)) + labs(title= title) +
+    geom_node_text(aes_(label=~name), data = p$data) +
     scale_size(range=c(3, 8) * pie_scale) + theme_void() + theme(legend.position="none") 
 }
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -158,9 +158,11 @@ cnetplot.compareClusterResult <- function(x,
         V(g)$size[1] <- 3
         V(g)$color <- "#B3B3B3"
         V(g)$color[1] <- "#E5C494"
+        title <- y$Cluster 
         p <- ggraph(g, layout=layout, circular=circular) +
             edge_layer + theme_void() +
             geom_node_point(aes_(color=~I(color), size=~size)) + 
+            labs(title= title) +
             scale_size(range=c(3, 8) * pie_scale) + theme(legend.position="none") 
             
         return(p)

--- a/man/cnetplot.Rd
+++ b/man/cnetplot.Rd
@@ -5,6 +5,7 @@
 \alias{cnetplot}
 \alias{cnetplot,enrichResult-method}
 \alias{cnetplot,gseaResult-method}
+\alias{cnetplot,compareClusterResult-method}
 \alias{cnetplot.enrichResult}
 \title{cnetplot}
 \usage{
@@ -15,6 +16,9 @@ cnetplot(x, showCategory = 5, foldChange = NULL, layout = "kk", ...)
 
 \S4method{cnetplot}{gseaResult}(x, showCategory = 5, foldChange = NULL,
   layout = "kk", ...)
+
+\S4method{cnetplot}{compareClusterResult}(x, showCategory = 5,
+  foldChange = NULL, layout = "kk", ...)
 
 cnetplot.enrichResult(x, showCategory = 5, foldChange = NULL,
   layout = "kk", colorEdge = FALSE, circular = FALSE,


### PR DESCRIPTION
1、为了使`enrichplot` 包中的 `cnetplot`函数更好地处理compareClusterResult数据，在DOSE中进行如下更改：
    1）、为`compareClusterResult` 增加一个slot： gene2Symbol
    2）、增加`geneID.compareClusterResult()`，`geneInCategory.compareClusterResult()`
    3）、为`setReadable`函数增加处理compareClusterResult数据的功能
2、增加`cnetplot.compareClusterResult()`, `deal_gene_pie()`。
其中`deal_gene_pie()`函数的功能类似于emapplot.R 文件中的`deal_data_pie()`. 区别在于：`deal_data_pie()` 是做出Category的数据框的，`deal_gene_pie()` 是做出gene的数据框的。
