### PR TITLE
fix str_count in case of no match

### DIFF
--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -147,7 +147,7 @@ fortify.internal <- function(model, data, showCategory=5, by = "Count", order=FA
     res <- as.data.frame(model)
     res <- res[!is.na(res$Description), ]
     if (inherits(model, "gseaResult")) {
-        res$Count <- str_count(res$core_enrichment, "/") + 1
+        res$Count <- str_count(res$core_enrichment, "/")
         res$.sign <- "activated"
         res$.sign[res$NES < 0] <- "suppressed"
     }
@@ -199,11 +199,7 @@ fortify.internal <- function(model, data, showCategory=5, by = "Count", order=FA
 }
 
 str_count <- function(string, pattern="") {
-    sapply(string, str_count_item, pattern=pattern)
-}
-
-str_count_item <- function(string, pattern = "") {
-    length(gregexpr(pattern, string)[[1]])
+    sapply(string, FUN = function(i) length(unlist(strsplit(i, split = pattern))))
 }
 
 parse_ratio <- function(ratio) {


### PR DESCRIPTION
`gregexpr` returns -1 in case of no match, so check the length of the returned vector is not appropriate