### PR TITLE
fix `showCategory` and `pairwise_termsim`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.11.1
+Version: 1.11.1.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))
@@ -9,7 +9,7 @@ Description: The 'enrichplot' package implements several visualization methods f
 Depends: R (>= 3.5.0)
 Imports:
     cowplot,
-    DOSE,
+    DOSE (>= 3.16.0),
     ggplot2,
     ggraph,
     graphics,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # enrichplot 1.11.1.991
 
-+ fix `pairwise_termsim` (2020-12-23, Wed)
-+ fix `showCategory` for `cnetplot`, `emapplot`, `emapplot_cluster` 
++ fix `pairwise_termsim` for the bug of repeated filtering of `showCategory`(2020-12-23, Wed)
++ fix `showCategory` for `cnetplot`, `emapplot`, `emapplot_cluster` when  `showCategory` is a vector of term descriptions
 
 
 # enrichplot 1.11.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# enrichplot 1.11.1.991
+
++ fix `pairwise_termsim` (2020-12-23, Wed)
++ fix `showCategory` for `cnetplot`, `emapplot`, `emapplot_cluster` 
+
+
 # enrichplot 1.11.1
 
 + add `orderBy` and `decreasing` parameters for `ridgeplot()` (2020-11-19, Thu)

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -105,7 +105,7 @@ setGeneric("emapplot",
 ##'     ego <- enrichGO(gene  = gene,
 ##'         universe      = names(geneList),
 ##'         OrgDb         = org.Hs.eg.db,
-##'         ont           = "CC",
+##'         ont           = "BP",
 ##'         pAdjustMethod = "BH",
 ##'         pvalueCutoff  = 0.01,
 ##'         qvalueCutoff  = 0.05,
@@ -115,10 +115,12 @@ setGeneric("emapplot",
 ##'     emapplot_cluster(ego2, showCategory = 80)
 ##'    }
 setGeneric("emapplot_cluster",
-           function(x, showCategory = nrow(x), color="p.adjust", label_format = 30, ...)
+           function(x, showCategory = 30, color="p.adjust", label_format = 30, ...)
                standardGeneric("emapplot_cluster")
            )
+           
 
+           
 ##' Get the similarity matrix
 ##'
 ##'
@@ -154,7 +156,7 @@ setGeneric("emapplot_cluster",
 ##'     emapplot_cluster(ego2)
 ##'    }
 setGeneric("pairwise_termsim",
-           function(x, method = "JC", semData = NULL, showCategory = 30)
+           function(x, method = "JC", semData = NULL, showCategory = 200)
                standardGeneric("pairwise_termsim")
            )
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -245,27 +245,10 @@ cnetplot.compareClusterResult <- function(x,
     range_gene_size <- c(3, 3)
     ## If showCategory is a number, keep only the first showCategory of each group,
     ## otherwise keep the total showCategory rows
-    if (is.numeric(showCategory)) {
-        y <- fortify(x, showCategory = showCategory,
-                                      includeAll = TRUE, split = split)
-        y_union <- merge_compareClusterResult(y)
-    } else {
-        y <- fortify(x, showCategory=NULL,
-                                      includeAll = TRUE, split = split)
-        n <- update_n(y_union, showCategory)
-        y_union <- merge_compareClusterResult(y)
-        y_union <- y_union[match(n, y_union$Description),]    
-    } 
-    # y <- fortify(x, showCategory=showCategory,
-        # includeAll=TRUE, split=split)
-    y$Cluster <- sub("\n.*", "", y$Cluster)
-
-
-    # y_union <- get_y_union(y = y, showCategory = showCategory)
-    y <- y[y$ID %in% y_union$ID, ]
+    ylist <- keep_showCategory(showCategory, x, split)  
+    y_union <- ylist[["y_union"]]
+    y <- ylist[["y"]]
     node_label <- match.arg(node_label, c("category", "gene", "all", "none"))
-
-
     if (circular) {
         layout <- "linear"
         geom_edge <- geom_edge_arc

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -245,9 +245,9 @@ cnetplot.compareClusterResult <- function(x,
     range_gene_size <- c(3, 3)
     ## If showCategory is a number, keep only the first showCategory of each group,
     ## otherwise keep the total showCategory rows
-    ylist <- keep_showCategory(showCategory, x, split)  
-    y_union <- ylist[["y_union"]]
-    y <- ylist[["y"]]
+    y <- get_selected_category(showCategory, x, split)  
+    ## Data structure transformation, combining the same ID (Description) genes
+    y_union <- merge_compareClusterResult(y)
     node_label <- match.arg(node_label, c("category", "gene", "all", "none"))
     if (circular) {
         layout <- "linear"

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -243,12 +243,25 @@ cnetplot.compareClusterResult <- function(x,
     label_gene <- 2.5
     range_category_size <- c(3, 8)
     range_gene_size <- c(3, 3)
-    y <- fortify(x, showCategory=showCategory,
-        includeAll=TRUE, split=split)
+    ## If showCategory is a number, keep only the first showCategory of each group,
+    ## otherwise keep the total showCategory rows
+    if (is.numeric(showCategory)) {
+        y <- fortify(x, showCategory = showCategory,
+                                      includeAll = TRUE, split = split)
+        y_union <- merge_compareClusterResult(y)
+    } else {
+        y <- fortify(x, showCategory=NULL,
+                                      includeAll = TRUE, split = split)
+        n <- update_n(y_union, showCategory)
+        y_union <- merge_compareClusterResult(y)
+        y_union <- y_union[match(n, y_union$Description),]    
+    } 
+    # y <- fortify(x, showCategory=showCategory,
+        # includeAll=TRUE, split=split)
     y$Cluster <- sub("\n.*", "", y$Cluster)
 
 
-    y_union <- get_y_union(y = y, showCategory = showCategory)
+    # y_union <- get_y_union(y = y, showCategory = showCategory)
     y <- y[y$ID %in% y_union$ID, ]
     node_label <- match.arg(node_label, c("category", "gene", "all", "none"))
 

--- a/R/emapplot.R
+++ b/R/emapplot.R
@@ -362,27 +362,9 @@ emapplot.compareClusterResult <- function(x, showCategory = 30,
     ## pretreatment of x, just like dotplot do
     ## If showCategory is a number, keep only the first showCategory of each group
     ## Otherwise keep the total showCategory rows
-    if (is.numeric(showCategory)) {
-        y <- fortify(x, showCategory = showCategory,
-                                      includeAll = TRUE, split = split)
-        y_union <- merge_compareClusterResult(y)
-    } else {
-        y <- fortify(x, showCategory=NULL,
-                                      includeAll = TRUE, split = split)
-        n <- update_n(y_union, showCategory)
-        y_union <- merge_compareClusterResult(y)
-        y_union <- y_union[match(n, y_union$Description),]    
-    }   
-    
-    y$Cluster <- sub("\n.*", "", y$Cluster)
-    ## geneSets <- geneInCategory(x) ## use core gene for gsea result
-
-    ## Data structure transformation, combining the same ID (Description) genes
-        
-    #y_union <- get_y_union(y = y, showCategory = showCategory)
-    
- 
-    y <- y[y$ID %in% y_union$ID, ]
+    ylist <- keep_showCategory(showCategory, x, split)  
+    y_union <- ylist[["y_union"]]
+    y <- ylist[["y"]]
 
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
                                   fixed = TRUE), y_union$ID)
@@ -522,7 +504,23 @@ get_y_union <- function(y, showCategory){
    return(y_union)
 }
 
-
+keep_showCategory <- function(showCategory, x, split) {
+    if (is.numeric(showCategory)) {
+        y <- fortify(x, showCategory = showCategory,
+                                      includeAll = TRUE, split = split)
+        y_union <- merge_compareClusterResult(y)
+    } else {  
+        y <- as.data.frame(x)  
+        y <- y[y$Description %in% showCategory, ]        
+        y <- fortify(y, showCategory=NULL,
+                                      includeAll = TRUE, split = split)                                              
+        y_union <- merge_compareClusterResult(y)  
+    }  
+    ## Data structure transformation, combining the same ID (Description) genes    
+    y$Cluster <- sub("\n.*", "", y$Cluster)
+    y <- y[y$ID %in% y_union$ID, ]    
+    ylist <- list(y_union =  y_union, y = y)
+}
 
 
 

--- a/R/emapplot.R
+++ b/R/emapplot.R
@@ -103,7 +103,7 @@ has_pairsim <- function(x) {
 ##' "JC" (Jaccard similarity coefficient) methods
 ##' @return result of graph.data.frame()
 ##' @noRd
-emap_graph_build <- function(y, geneSets, color, cex_line, min_edge, 
+emap_graph_build <- function(y, geneSets, color, cex_line, min_edge,
                              pair_sim  = NULL, method = NULL) {
 
     if (!is.numeric(min_edge) | min_edge < 0 | min_edge > 1) {
@@ -175,7 +175,7 @@ get_igraph <- function(x, y,  n, color, cex_line, min_edge){
     if (n == 0) {
         stop("no enriched term found...")
     }
-    
+
     g <- emap_graph_build(y = y, geneSets = geneSets, color = color,
              cex_line = cex_line, min_edge = min_edge,
              pair_sim = x@termsim, method = x@method)
@@ -216,9 +216,9 @@ emapplot.enrichResult <- function(x, showCategory = 30, color="p.adjust",
     layout = "nicely", node_scale = NULL, line_scale = NULL, min_edge=0.2,
     node_label_size = NULL, cex_label_category  = 1, cex_category = NULL,
     cex_line = NULL) {
-    
+
     has_pairsim(x)
-    if (!is.null(node_label_size)) 
+    if (!is.null(node_label_size))
         message("node_label_size parameter has been changed to 'cex_label_category'")
     # if (is.null(cex_label_category)) {
         # if (!is.null(node_label_size)) {
@@ -228,7 +228,7 @@ emapplot.enrichResult <- function(x, showCategory = 30, color="p.adjust",
         # }
     # }
 
-    if (!is.null(node_scale)) 
+    if (!is.null(node_scale))
         message("node_scale parameter has been changed to 'cex_category'")
     if (is.null(cex_category)) {
         if (!is.null(node_scale)) {
@@ -238,7 +238,7 @@ emapplot.enrichResult <- function(x, showCategory = 30, color="p.adjust",
         }
     }
 
-    if (!is.null(line_scale)) 
+    if (!is.null(line_scale))
         message("line_scale parameter has been changed to 'cex_line'")
     if (is.null(cex_line)) {
         if (!is.null(line_scale)) {
@@ -362,9 +362,9 @@ emapplot.compareClusterResult <- function(x, showCategory = 30,
     ## pretreatment of x, just like dotplot do
     ## If showCategory is a number, keep only the first showCategory of each group
     ## Otherwise keep the total showCategory rows
-    ylist <- keep_showCategory(showCategory, x, split)  
-    y_union <- ylist[["y_union"]]
-    y <- ylist[["y"]]
+    y <- get_selected_category(showCategory, x, split)
+    ## Data structure transformation, combining the same ID (Description) genes
+    y_union <- merge_compareClusterResult(y)
 
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
                                   fixed = TRUE), y_union$ID)
@@ -504,22 +504,25 @@ get_y_union <- function(y, showCategory){
    return(y_union)
 }
 
-keep_showCategory <- function(showCategory, x, split) {
+##' Keep selected category in enrichment result
+##'
+##' @param showCategory a number or a vectory of enriched terms to display
+##' @param x enrichment result
+##' @param split separate result by 'category' variable
+##' @noRd
+get_selected_category <- function(showCategory, x, split) {
     if (is.numeric(showCategory)) {
         y <- fortify(x, showCategory = showCategory,
                                       includeAll = TRUE, split = split)
-        y_union <- merge_compareClusterResult(y)
-    } else {  
-        y <- as.data.frame(x)  
-        y <- y[y$Description %in% showCategory, ]        
+
+    } else {
+        y <- as.data.frame(x)
+        y <- y[y$Description %in% showCategory, ]
         y <- fortify(y, showCategory=NULL,
-                                      includeAll = TRUE, split = split)                                              
-        y_union <- merge_compareClusterResult(y)  
-    }  
-    ## Data structure transformation, combining the same ID (Description) genes    
+                                      includeAll = TRUE, split = split)
+    }
     y$Cluster <- sub("\n.*", "", y$Cluster)
-    y <- y[y$ID %in% y_union$ID, ]    
-    ylist <- list(y_union =  y_union, y = y)
+    return(y)
 }
 
 

--- a/R/emapplot.R
+++ b/R/emapplot.R
@@ -64,6 +64,7 @@ get_ww <- function(y, geneSets, method, semData = NULL) {
     }
 
     if (y_id == "DOID") w <- DOSE::doSim(id, id, measure=method)
+    rownames(y) <- y$ID
     rownames(w) <- colnames(w) <- y[colnames(w), "Description"]
     return(w)
 }

--- a/R/emapplot_cluster.R
+++ b/R/emapplot_cluster.R
@@ -213,9 +213,9 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
 
     has_pairsim(x)
     label_group <- 3
-    ylist <- keep_showCategory(showCategory, x, split)  
-    y_union <- ylist[["y_union"]]
-    y <- ylist[["y"]]
+    y <- get_selected_category(showCategory, x, split)  
+    ## Data structure transformation, combining the same ID (Description) genes
+    y_union <- merge_compareClusterResult(y)
 
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
                                   fixed = TRUE), y_union$ID)

--- a/R/emapplot_cluster.R
+++ b/R/emapplot_cluster.R
@@ -213,25 +213,9 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
 
     has_pairsim(x)
     label_group <- 3
-    
-    if (is.numeric(showCategory)) {
-        y <- fortify(x, showCategory = showCategory,
-                                      includeAll = TRUE, split = split)
-        y_union <- merge_compareClusterResult(y)
-    } else {
-        y <- fortify(x, showCategory=NULL,
-                                      includeAll = TRUE, split = split)
-        n <- update_n(y_union, showCategory)
-        y_union <- merge_compareClusterResult(y)
-        y_union <- y_union[match(n, y_union$Description),]    
-    }   
-    
-    y$Cluster <- sub("\n.*", "", y$Cluster)
-    # y <- fortify(x, showCategory=showCategory, includeAll=TRUE, split=split)
-    # y$Cluster <- sub("\n.*", "", y$Cluster)
-
-    # y_union <- get_y_union(y = y, showCategory = showCategory)
-    y <- y[y$ID %in% y_union$ID, ]
+    ylist <- keep_showCategory(showCategory, x, split)  
+    y_union <- ylist[["y_union"]]
+    y <- ylist[["y"]]
 
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
                                   fixed = TRUE), y_union$ID)

--- a/R/emapplot_cluster.R
+++ b/R/emapplot_cluster.R
@@ -35,7 +35,7 @@ setMethod("emapplot_cluster", signature(x = "compareClusterResult"),
 ##' @param label_style one of "shadowtext" and "ggforce"
 ##' @param group_legend If TRUE, the grouping legend will be displayed.
 ##' The default is FALSE
-##' @param cex_category number indicating the amount by which plotting category
+##' @param cex_category number indicating the size by which plotting category
 ##' nodes should be scaled relative to the default.
 ##' @param label_format a numeric value sets wrap length, alternatively a
 ##' custom function to format axis labels.
@@ -213,10 +213,24 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
 
     has_pairsim(x)
     label_group <- 3
-    y <- fortify(x, showCategory=showCategory, includeAll=TRUE, split=split)
+    
+    if (is.numeric(showCategory)) {
+        y <- fortify(x, showCategory = showCategory,
+                                      includeAll = TRUE, split = split)
+        y_union <- merge_compareClusterResult(y)
+    } else {
+        y <- fortify(x, showCategory=NULL,
+                                      includeAll = TRUE, split = split)
+        n <- update_n(y_union, showCategory)
+        y_union <- merge_compareClusterResult(y)
+        y_union <- y_union[match(n, y_union$Description),]    
+    }   
+    
     y$Cluster <- sub("\n.*", "", y$Cluster)
+    # y <- fortify(x, showCategory=showCategory, includeAll=TRUE, split=split)
+    # y$Cluster <- sub("\n.*", "", y$Cluster)
 
-    y_union <- get_y_union(y = y, showCategory = showCategory)
+    # y_union <- get_y_union(y = y, showCategory = showCategory)
     y <- y[y$ID %in% y_union$ID, ]
 
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",

--- a/R/pairwise_termsim.R
+++ b/R/pairwise_termsim.R
@@ -48,7 +48,8 @@ pairwise_termsim.compareClusterResult <- function(x, method = "JC", semData = NU
                                                   showCategory = 200) {
     y <- fortify(x, showCategory=showCategory, includeAll=TRUE, split=NULL)
     y$Cluster <- sub("\n.*", "", y$Cluster)
-    y_union <- get_y_union(y = y, showCategory = showCategory)
+    ## y_union <- get_y_union(y = y, showCategory = showCategory)
+    y_union <- merge_compareClusterResult(y)
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
                                   fixed = TRUE), 
                          y_union$ID)

--- a/R/wordcloud.R
+++ b/R/wordcloud.R
@@ -22,18 +22,18 @@ get_w <- function(wordd){
 ##' @importFrom magrittr %>%
 wordcloud_i <- function(cluster, pdata2, nWords){
     words <- pdata2$name %>%
-        gsub(" in ", "", .) %>%
+        gsub(" in ", " ", .) %>%
         gsub(" [0-9]+ ", " ", .) %>%
         gsub("^[0-9]+ ", "", .) %>%
         gsub(" [0-9]+$", "", .) %>%
         gsub(" [A-Za-z] ", " ", .) %>%
         gsub("^[A-Za-z] ", "", .) %>%
         gsub(" [A-Za-z]$", "", .) %>%
-        gsub(" / ", "", .) %>%
-        gsub(" and ", "", .) %>%
-        gsub(" of ", "", .) %>%
-        gsub(",", "", .) %>%
-        gsub(" - ", "", .)
+        gsub(" / ", " ", .) %>%
+        gsub(" and ", " ", .) %>%
+        gsub(" of ", " ", .) %>%
+        gsub(",", " ", .) %>%
+        gsub(" - ", " ", .)
     net_tot <- length(words)
 
     clusters <- unique(pdata2$color)

--- a/man/emapplot_cluster.Rd
+++ b/man/emapplot_cluster.Rd
@@ -11,7 +11,7 @@
 \usage{
 emapplot_cluster(
   x,
-  showCategory = nrow(x),
+  showCategory = 30,
   color = "p.adjust",
   label_format = 30,
   ...
@@ -35,7 +35,7 @@ emapplot_cluster(
 
 \S4method{emapplot_cluster}{compareClusterResult}(
   x,
-  showCategory = nrow(x),
+  showCategory = 30,
   color = "p.adjust",
   label_format = 30,
   ...
@@ -123,7 +123,7 @@ should between 0 and 1, default value is 0.2}
 \item{group_legend}{If TRUE, the grouping legend will be displayed.
 The default is FALSE}
 
-\item{cex_category}{number indicating the amount by which plotting category
+\item{cex_category}{number indicating the size by which plotting category
 nodes should be scaled relative to the default.}
 
 \item{repel}{whether to correct the position of the label. Defaults to FALSE.}
@@ -157,7 +157,7 @@ for interpretation.
     ego <- enrichGO(gene  = gene,
         universe      = names(geneList),
         OrgDb         = org.Hs.eg.db,
-        ont           = "CC",
+        ont           = "BP",
         pAdjustMethod = "BH",
         pvalueCutoff  = 0.01,
         qvalueCutoff  = 0.05,

--- a/man/pairwise_termsim.Rd
+++ b/man/pairwise_termsim.Rd
@@ -9,7 +9,7 @@
 \alias{pairwise_termsim.compareClusterResult}
 \title{pairwise_termsim}
 \usage{
-pairwise_termsim(x, method = "JC", semData = NULL, showCategory = 30)
+pairwise_termsim(x, method = "JC", semData = NULL, showCategory = 200)
 
 \S4method{pairwise_termsim}{enrichResult}(x, method = "JC", semData = NULL, showCategory = 200)
 


### PR DESCRIPTION
老师，我将bug修复整理成了一次提交，主要是修改`showCategory`的作用思路，这次提交主要更改如下：

1. showCategory的bug修复：

   - 修改了 `cnetplot`、 `emapplot` 和 `emapplot_cluster`中showCategory参数的作用思路。我之前的代码中没有考虑到当showCategory为一个term Description的向量时`compareClusterResult`的作图情况，此次进行了修正，思路为：
     如果`showCategory`为一个数字，那么就使用`fortify(showCategory = showCategory, ...)`保留每组前`showCategory`个term。如果`showCategory`为一个term 名字的向量，那么使用`fortify(showCategory = NULL, ...)`不对每组进行筛选，而是在之后的步骤中将`showCategory`中的term挑选出来作图。

   - 之前`pairwise_termsim.compareClusterResult` 的代码有个重复筛选showCategory的问题：

     在https://github.com/YuLab-SMU/enrichplot/blob/master/R/pairwise_termsim.R#L49-L51 中，已经通过fortify来提取各组前showCategory个的term了，但是后面我又用`get_y_union`保留了总体结果的前showCategory行，这是不合理的。因此我删去了`get_y_union`的这一步筛选。
[test_showCategory2.pdf](https://github.com/YuLab-SMU/enrichplot/files/5733783/test_showCategory2.pdf)


2. 之前`pairwise_termsim`函数当`method`参数为默认值时，结果的行名和列名为 term Description，而当`method` 参数为其他值时，结果的行名和列名为 term Id，两者不统一。此次修复了这个问题。`emap_graph_build`中的代码跟着做了修改。

3. 之前wordcloud.R的代码中有一些空格方面的问题，此次进行了修正。

4. 在DESCRIPTION文件中，为Imports: DOSE添加了版本号DOSE (>= 3.16.0)。因为之前几次更新中为`compareClusterResult`添加了几个slots，用户如果不更新DOSE的话会报错。



