### PR TITLE
fix bug in `emapplot` and `cnetplot` when enrichment result is one line

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.11.1.991
+Version: 1.11.1.992
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# enrichplot 1.11.1.992
+
++ fix bug in `emapplot` and `cnetplot` when enrichment result is one line (2020-12-26, Sat)
+
+
+
 # enrichplot 1.11.1.991
 
 + fix `pairwise_termsim` for the bug of repeated filtering of `showCategory`(2020-12-23, Wed)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,6 @@
 # enrichplot 1.11.1.992
 
 + fix bug in `emapplot` and `cnetplot` when enrichment result is one line (2020-12-26, Sat)
-
-
-
-# enrichplot 1.11.1.991
-
 + fix `pairwise_termsim` for the bug of repeated filtering of `showCategory`(2020-12-23, Wed)
 + fix `showCategory` for `cnetplot`, `emapplot`, `emapplot_cluster` when  `showCategory` is a vector of term descriptions
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -300,7 +300,7 @@ cnetplot.compareClusterResult <- function(x,
     }
 
     if(is.null(dim(y_union)) | nrow(y_union) == 1) {
-        p <- ggraph(g) + edge_layer
+        p <- ggraph(g, "tree") + edge_layer
     } else {
         p <- ggraph(g, layout=layout, circular=circular) + edge_layer
     }

--- a/R/emapplot.R
+++ b/R/emapplot.R
@@ -115,6 +115,7 @@ emap_graph_build <- function(y, geneSets, color, cex_line, min_edge,
         g <- add_vertices(g, nv = 1)
         V(g)$name <- as.character(y$Description)
         V(g)$color <- "red"
+        return(g)
     } else {
         # w <- pair_sim
         # if (method == "JC") {
@@ -256,7 +257,7 @@ emapplot.enrichResult <- function(x, showCategory = 30, color="p.adjust",
     g <- get_igraph(x=x, y=y, n=n, color=color, cex_line=cex_line,
                     min_edge=min_edge)
     if(n == 1) {
-        return(ggraph(g) + geom_node_point(color="red", size=5) +
+        return(ggraph(g,"tree") + geom_node_point(color="red", size=5) +
                geom_node_text(aes_(label=~name)))
     }
 
@@ -374,7 +375,7 @@ emapplot.compareClusterResult <- function(x, showCategory = 30,
                           pair_sim = x@termsim, method = x@method)
 
     p <- get_p(y = y, g = g, y_union = y_union, cex_category = cex_category,
-               pie = pie, layout = layout)
+               pie = pie, layout = layout)               
     if (is.null(dim(y)) | nrow(y) == 1 | is.null(dim(y_union)) | nrow(y_union) == 1)
         return(p)
 
@@ -458,7 +459,7 @@ get_p <- function(y, g, y_union, cex_category, pie, layout){
     ## when y just have one line
     if(is.null(dim(y)) | nrow(y) == 1) {
         title <- y$Cluster
-        p <- ggraph(g) + geom_node_point(color="red", size=5 * cex_category) +
+        p <- ggraph(g, "tree") + geom_node_point(color="red", size=5 * cex_category) +
             geom_node_text(aes_(label=~name)) + theme_void() +
             labs(title=title)
         return(p)
@@ -466,7 +467,7 @@ get_p <- function(y, g, y_union, cex_category, pie, layout){
 
     if(is.null(dim(y_union)) | nrow(y_union) == 1) {
         ##return(ggraph(g) + geom_node_point(color="red", size=5) + geom_node_text(aes_(label=~name)))
-        p <- ggraph(g)
+        p <- ggraph(g, "tree")
         ID_Cluster_mat <- prepare_pie_category(y, pie=pie)
 
         ID_Cluster_mat <- cbind(ID_Cluster_mat,1,1,0.1*cex_category)

--- a/R/emapplot_cluster.R
+++ b/R/emapplot_cluster.R
@@ -82,7 +82,7 @@ emapplot_cluster.enrichResult <- function(x, showCategory = 30,
     g <- get_igraph(x=x, y=y, n=n, color=color, cex_line=cex_line,
                     min_edge=min_edge)
     if(n == 1) {
-        return(ggraph(g) + geom_node_point(color="red", size=5) +
+        return(ggraph(g, "tree") + geom_node_point(color="red", size=5) +
                  geom_node_text(aes_(label=~name)))
     }
     edgee <- igraph::get.edgelist(g)
@@ -216,10 +216,11 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
     y <- get_selected_category(showCategory, x, split)  
     ## Data structure transformation, combining the same ID (Description) genes
     y_union <- merge_compareClusterResult(y)
-
+    
     geneSets <- setNames(strsplit(as.character(y_union$geneID), "/",
-                                  fixed = TRUE), y_union$ID)
-      
+                                  fixed = TRUE), y_union$ID) 
+
+                                  
     g <- emap_graph_build(y=y_union,geneSets=geneSets,color=color,
         cex_line=cex_line, min_edge=min_edge, pair_sim = x@termsim, 
         method = x@method)
@@ -242,9 +243,9 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
     pdata2 <- p$data
     dat <- data.frame(x = pdata2$x, y = pdata2$y)
     colnames(pdata2)[5] <- "color2"
-
+    
     if (is.null(nCluster)){
-        pdata2$color <- kmeans(dat, ceiling(sqrt(nrow(dat))))$cluster
+        pdata2$color <- kmeans(dat, floor(sqrt(nrow(dat))))$cluster
     } else {
         if (nCluster > nrow(dat)) nCluster <- nrow(dat)
         pdata2$color <- kmeans(dat, nCluster)$cluster


### PR DESCRIPTION
老师，`emaplot`、`emapplot_cluster` 和 `cnetplot`确实有他说的问题。但是他的修改并没有改全。我这次提交主要修改如下：
1. 当富集结果仅有一行时，ggraph的layout统一改成“tree”。
2. 在`emapplot_cluster`中当节点数为2时，在默认聚类方法下进行K均值聚类时，如果使用kmeans(dat, ceiling(sqrt(nrow(dat))))，即kemans(dat, 2)会产生报错。这里我改成了kmeans(dat, floor(sqrt(nrow(dat))))$cluster。他提交的修改聚类方法就是为了解决这个问题。我分别使用了以下几个数据进行测试：
 - enrichResult，只有一行结果。
 - compareClusterResult，只有一行结果。
 - compareClusterResult，富集到两组结果，每组都只有一行，并且是不同的term。
 - compareClusterResult，富集到两组结果，每组都只有一行，并且是同一个term。
 
[test_oneline.pdf](https://github.com/YuLab-SMU/enrichplot/files/5742921/test_oneline.pdf)
