### PR TITLE
Fix treeplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.11.2.992
+Version: 1.11.2.993
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.11.2.992
+# enrichplot 1.11.2.993
 
++ fix bug in `treeplot`: The legend is not the right size (2021-2-6, Sat).
 + fix `dotplot` for `label_format` parameter doesn't work(2021-2-3, Wed).
 + fix bug in `gseaplot2`(2021-1-28, Thu)
 

--- a/R/treeplot.R
+++ b/R/treeplot.R
@@ -164,7 +164,8 @@ treeplot.compareClusterResult <-  function(x, showCategory = 5,
     p + ggnewscale::new_scale_fill() +
         scatterpie::geom_scatterpie(aes_(x=~x,y=~y,r=~radius), data=ID_Cluster_mat,
                 cols=colnames(ID_Cluster_mat)[1:(ncol(ID_Cluster_mat)-4)],color=NA) +
-        scatterpie::geom_scatterpie_legend(cex_category * ID_Cluster_mat$radius,
+        # scatterpie::geom_scatterpie_legend(cex_category * ID_Cluster_mat$radius,
+        scatterpie::geom_scatterpie_legend(ID_Cluster_mat$radius,
             x = 0.8, y = 0.1, n = legend_n,
             labeller = function(x) round(sum(p_data$count) * x^2 / cex_category)) +
         coord_equal(xlim = xlim) +


### PR DESCRIPTION
老师，我此次提交是为了修改`treeplot.compareClusterResult`的scatterpie::geom_scatterpie的legend问题。之前版本我在`scatterpie::geom_scatterpie_legend`错误的使用了`cex_category * ID_Cluster_mat$radius`，最后画出的图中的legend会是实际大小的`cex_category`倍 。修改后跑出的例子如下：
[test_treeplot.pdf](https://github.com/YuLab-SMU/enrichplot/files/5934180/test_treeplot.pdf)
