### PR TITLE
Update emapplot cluster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.11.2.993
+Version: 1.11.2.994
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.11.2.993
+# enrichplot 1.11.2.994
 
++ fix bug in `emapplot_cluster.enrichResult` when the number of cluster is 2 (2021-2-24, Wed)
 + fix bug in `treeplot`: The legend is not the right size (2021-2-6, Sat).
 + fix `dotplot` for `label_format` parameter doesn't work(2021-2-3, Wed).
 + fix bug in `gseaplot2`(2021-1-28, Thu)

--- a/R/emapplot_cluster.R
+++ b/R/emapplot_cluster.R
@@ -42,6 +42,8 @@ setMethod("emapplot_cluster", signature(x = "compareClusterResult"),
 ##' custom function to format axis labels.
 ##' @param repel whether to correct the position of the label. Defaults to FALSE.
 ##' @param shadowtext a logical value, whether to use shadow font. Defaults to TRUE.
+##' @param layout Layout of the map, e.g. 'star', 'circle', 'gem', 'dh', 'graphopt', 'grid', 'mds', 
+##' 'randomly', 'fr', 'kk', 'drl' or 'lgl'.
 ##' @param ... Additional parameters used to set the position of the group label.
 ##' When the parameter repel is set to TRUE, additional parameters will take effect.
 ##' 
@@ -75,7 +77,7 @@ emapplot_cluster.enrichResult <- function(x, showCategory = 30,
                                           label_style = "shadowtext", 
                                           group_legend = FALSE, cex_category = 1, 
                                           label_format = 30, repel = FALSE, 
-                                          shadowtext = TRUE, ...){
+                                          shadowtext = TRUE, layout = "nicely", ...){
                                           
 
     has_pairsim(x)
@@ -91,11 +93,12 @@ emapplot_cluster.enrichResult <- function(x, showCategory = 30,
     }
     edgee <- igraph::get.edgelist(g)
  
-    edge_w <- E(g)$weight
-    set.seed(123)
-    lw <- layout_with_fr(g, weights=edge_w)
+    #edge_w <- E(g)$weight
+    ## set.seed(123)
+    #lw <- layout_with_fr(g, weights=edge_w)
 
-    p <- ggraph::ggraph(g, layout=lw)
+    #p <- ggraph::ggraph(g, layout=lw)
+    p <- ggraph(g, layout = layout)
     # cluster_label1 <- lapply(clusters, function(i){i[order(y[i, "pvalue"])[1]]})
 
     ## Using k-means clustering to group
@@ -104,7 +107,7 @@ emapplot_cluster.enrichResult <- function(x, showCategory = 30,
     colnames(pdata2)[5] <- "color2"
 
     if(is.null(nCluster)){
-        pdata2$color <- kmeans(dat, ceiling(sqrt(nrow(dat))))$cluster
+        pdata2$color <- kmeans(dat, floor(sqrt(nrow(dat))))$cluster
     } else {
         if(nCluster > nrow(dat)) nCluster <- nrow(dat)
         pdata2$color <- kmeans(dat, nCluster)$cluster
@@ -188,7 +191,7 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
     nWords = 4, nCluster = NULL, split = NULL, min_edge = 0.2,
     cex_label_group = 1, pie = "equal", legend_n = 5,
     cex_category = 1, label_style = "shadowtext", group_legend = FALSE, 
-    label_format = 30, repel = FALSE, shadowtext = TRUE, ...){
+    label_format = 30, repel = FALSE, shadowtext = TRUE, layout = "nicely", ...){
 
     has_pairsim(x)
     label_group <- 3
@@ -204,7 +207,7 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
         cex_line=cex_line, min_edge=min_edge, pair_sim = x@termsim, 
         method = x@method)
     p <- build_ggraph(y = y, g = g, y_union = y_union, cex_category = cex_category,
-        pie = pie, layout = "nicely")
+        pie = pie, layout = layout)
     if (is.null(dim(y)) | nrow(y) == 1 | is.null(dim(y_union)) | nrow(y_union) == 1)
         return(p)
 
@@ -213,11 +216,11 @@ emapplot_cluster.compareClusterResult <- function(x, showCategory = 30,
     ID_Cluster_mat <- prepare_pie_category(y, pie=pie)
 
     # Start the cluster diagram
-    edge_w <- E(g)$weight
-    set.seed(123)
-    lw <- layout_with_fr(g, weights=edge_w)
-    p <- ggraph(g, layout=lw)
-
+    # edge_w <- E(g)$weight
+    ## set.seed(123)
+    # lw <- layout_with_fr(g, weights=edge_w)
+    # p <- ggraph(g, layout=lw)
+    p <- ggraph(g, layout = layout) 
     ## Using k-means clustering to group
     pdata2 <- p$data
     dat <- data.frame(x = pdata2$x, y = pdata2$y)

--- a/man/emapplot_cluster.Rd
+++ b/man/emapplot_cluster.Rd
@@ -58,6 +58,7 @@ emapplot_cluster.enrichResult(
   label_format = 30,
   repel = FALSE,
   shadowtext = TRUE,
+  layout = "nicely",
   ...
 )
 
@@ -80,6 +81,7 @@ emapplot_cluster.compareClusterResult(
   label_format = 30,
   repel = FALSE,
   shadowtext = TRUE,
+  layout = "nicely",
   ...
 )
 }
@@ -134,6 +136,9 @@ nodes should be scaled relative to the default.}
 \item{repel}{whether to correct the position of the label. Defaults to FALSE.}
 
 \item{shadowtext}{a logical value, whether to use shadow font. Defaults to TRUE.}
+
+\item{layout}{Layout of the map, e.g. 'star', 'circle', 'gem', 'dh', 'graphopt', 'grid', 'mds', 
+'randomly', 'fr', 'kk', 'drl' or 'lgl'.}
 
 \item{pie}{Proportion of clusters in the pie chart, one of
 'equal' (default) and 'Count'.}


### PR DESCRIPTION
老师，我此次提交主要有以下三个更改：
1. 之前在 #95 的提交中漏改了`emapplot_cluster.enrichResult`，这次提交我把它也作了相应更改：将`kmeans(dat, ceiling(sqrt(nrow(dat))))$cluster` 改成了 `kmeans(dat, floor(sqrt(nrow(dat))))$cluster`， 以此来避免nrow(dat)=2时出错的情况。
2. 之前的版本中，`emapplot`有个`layout`参数供用户调整布局，而`emapplot_cluster`却没有。为了保持一致，这次我为`emapplot_cluster`也添加了这个参数，默认布局为"nicely"。我原来的代码 https://github.com/YuLab-SMU/enrichplot/blob/master/R/emapplot_cluster.R#L96-L98 是为了使节点间的距离代表节点间的相似度，但是我现在发现这几步操作是多余的，当使用默认layout参数nicely时本身就可以实现这个要求，原因写在了这个文件中：
[nicely布局.pdf](https://github.com/YuLab-SMU/enrichplot/files/6034138/nicely.pdf)
3. 之前我在代码中使用了`set.seed(123)`来保证每次结果都一致，不过它使用户的环境发生了变化，因此我这次把它删掉了，由用户在跑图的时候自己写上。