### PR TITLE
ggrepel options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.13.1.992
+Version: 1.13.1.993
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # enrichplot 1.13.1.993
 
-+ add `segment.size` parameter for `geom_node_text` through `getOption("ggrepel.segment.size")`(2021-08-29, Sun)
++ add `get_ggrepel_segsize` function to set `segment.size` value for `ggrepel`(2021-08-29, Sun)
 + update `ep_str_wrap` (2021-08-28, Sat)
 + `cnetplot` now works with a named list (2021-08-23, Mon; clusterProfiler#362)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.13.1.992
+# enrichplot 1.13.1.993
 
++ add `segment.size` parameter for `geom_node_text` through `getOption("ggrepel.segment.size")`(2021-08-29, Sun)
 + update `ep_str_wrap` (2021-08-28, Sat)
 + `cnetplot` now works with a named list (2021-08-23, Mon; clusterProfiler#362)
 

--- a/R/emapplot_utilities.R
+++ b/R/emapplot_utilities.R
@@ -193,6 +193,8 @@ merge_compareClusterResult <- function(yy) {
 build_ggraph <- function(x, enrichDf, mergedEnrichDf, cex_category, pie, 
                          layout, coords, cex_line, min_edge, pair_sim,
                          method, with_edge){
+    segment.size <- getOption("ggrepel.segment.size")
+    if (is.null(segment.size)) segment.size <- 0.2
     geneSets <- setNames(strsplit(as.character(mergedEnrichDf$geneID), "/",
                               fixed = TRUE), mergedEnrichDf$ID) 
                               
@@ -221,7 +223,7 @@ build_ggraph <- function(x, enrichDf, mergedEnrichDf, cex_category, pie,
                 cols=names(ID_Cluster_mat)[1:(ncol(ID_Cluster_mat)-3)],
                 color=NA)+
             xlim(-3,3) + ylim(-3,3) + coord_equal()+
-            geom_node_text(aes_(label=~name), repel=TRUE) +
+            geom_node_text(aes_(label=~name), repel=TRUE, segment.size = segment.size) +
             theme_void()+labs(fill = "Cluster")
         return(p)
 
@@ -374,12 +376,16 @@ add_group_label <- function(label_style, repel, shadowtext, p, label_location,
 ##' @return a ggplot2 object.
 ##' @noRd
 add_node_label <- function(p, data, label_size_node, cex_label_node, shadowtext) {
+    segment.size <- getOption("ggrepel.segment.size")
+    if (is.null(segment.size)) segment.size <- 0.2
     if (shadowtext) {
         p <- p + geom_node_text(aes_(label=~name), data = data,
-            size = label_size_node * cex_label_node, bg.color = "white", repel=TRUE)
+            size = label_size_node * cex_label_node, bg.color = "white", 
+            repel=TRUE, segment.size = segment.size)
     } else {
         p <- p + geom_node_text(aes_(label=~name), data = data,
-            size = label_size_node * cex_label_node, repel=TRUE)
+            size = label_size_node * cex_label_node, repel=TRUE,
+            segment.size = segment.size)
     }
     return(p)
 }

--- a/R/emapplot_utilities.R
+++ b/R/emapplot_utilities.R
@@ -193,8 +193,7 @@ merge_compareClusterResult <- function(yy) {
 build_ggraph <- function(x, enrichDf, mergedEnrichDf, cex_category, pie, 
                          layout, coords, cex_line, min_edge, pair_sim,
                          method, with_edge){
-    segment.size <- getOption("ggrepel.segment.size")
-    if (is.null(segment.size)) segment.size <- 0.2
+    segment.size <- get_ggrepel_segsize()
     geneSets <- setNames(strsplit(as.character(mergedEnrichDf$geneID), "/",
                               fixed = TRUE), mergedEnrichDf$ID) 
                               
@@ -338,6 +337,7 @@ get_label_location <- function(ggData, label_format) {
 add_group_label <- function(label_style, repel, shadowtext, p, label_location, 
                             label_group, cex_label_group, ...) {
     if (label_style != "shadowtext") return(p)
+    segment.size <- get_ggrepel_segsize()
     if (!repel) {
         if (shadowtext) {
             p <- p + geom_shadowtext(data = label_location,
@@ -356,12 +356,12 @@ add_group_label <- function(label_style, repel, shadowtext, p, label_location,
         p <- p + ggrepel::geom_text_repel(data = label_location,
             aes_(x =~ x, y =~ y, label =~ label), colour = "black",
             size = label_group * cex_label_group, bg.color = "white", bg.r = 0.1,
-            show.legend = FALSE, ...)
+            show.legend = FALSE, segment.size = segment.size, ...)
     } else {
         p <- p + ggrepel::geom_text_repel(data = label_location,
             aes_(x =~ x, y =~ y, label =~ label), colour = "black",
             size = label_group * cex_label_group, 
-            show.legend = FALSE, ...)
+            show.legend = FALSE, segment.size = segment.size, ...)
     }
     return(p)   
 }
@@ -376,8 +376,7 @@ add_group_label <- function(label_style, repel, shadowtext, p, label_location,
 ##' @return a ggplot2 object.
 ##' @noRd
 add_node_label <- function(p, data, label_size_node, cex_label_node, shadowtext) {
-    segment.size <- getOption("ggrepel.segment.size")
-    if (is.null(segment.size)) segment.size <- 0.2
+    segment.size <- get_ggrepel_segsize()
     if (shadowtext) {
         p <- p + geom_node_text(aes_(label=~name), data = data,
             size = label_size_node * cex_label_node, bg.color = "white", 

--- a/R/goplot.R
+++ b/R/goplot.R
@@ -29,6 +29,8 @@ setMethod("goplot", signature(x = "gseaResult"),
 ##' @author Guangchuang Yu
 goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
                                 layout = "sugiyama", geom = "text", ...) {
+    segment.size <- getOption("ggrepel.segment.size")
+    if (is.null(segment.size)) segment.size <- 0.2
     # has_package("AnnotationDbi")
     n <- update_n(x, showCategory)
     geneSets <- geneInCategory(x) ## use core gene for gsea result
@@ -79,7 +81,7 @@ goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
                 guide=guide_colorbar(reverse=TRUE), na.value="white")
         ## scale_fill_gradientn(name = color, colors=sig_palette, guide=guide_colorbar(reverse=TRUE), na.value='white')
     } else {
-        p <- p + geom_node_text(aes_(label=~Term), repel=TRUE)
+        p <- p + geom_node_text(aes_(label=~Term), repel=TRUE, segment.size = segment.size)
     }
     return(p)
 }

--- a/R/goplot.R
+++ b/R/goplot.R
@@ -29,8 +29,7 @@ setMethod("goplot", signature(x = "gseaResult"),
 ##' @author Guangchuang Yu
 goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
                                 layout = "sugiyama", geom = "text", ...) {
-    segment.size <- getOption("ggrepel.segment.size")
-    if (is.null(segment.size)) segment.size <- 0.2
+    segment.size <- get_ggrepel_segsize()
     # has_package("AnnotationDbi")
     n <- update_n(x, showCategory)
     geneSets <- geneInCategory(x) ## use core gene for gsea result
@@ -76,7 +75,8 @@ goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
     ## scale_color_gradientn(name = color, colors=sig_palette, guide=guide_colorbar(reverse=TRUE))
 
     if (geom == "label") {
-        p <- p + geom_node_label(aes_(label=~Term, fill=~color), repel=TRUE) +
+        p <- p + geom_node_label(aes_(label=~Term, fill=~color), 
+                                 repel=TRUE, segment.size = segment.size) +
             scale_fill_continuous(low="red", high="blue", name = color,
                 guide=guide_colorbar(reverse=TRUE), na.value="white")
         ## scale_fill_gradientn(name = color, colors=sig_palette, guide=guide_colorbar(reverse=TRUE), na.value='white')

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -377,4 +377,9 @@ default_labeller <- function(n) {
     }
 }
 
-
+#' Get segment.size value for ggrepel
+#' @default default value of ggrepel.segment.size
+#' @noRd
+get_ggrepel_segsize <- function(default = 0.2) {
+    getOption("ggrepel.segment.size", default = default)
+}


### PR DESCRIPTION
老师，我此次提交是通过`segment.size <- getOption("ggrepel.segment.size")`来获取`segment.size`的值，从而对`geom_node_text`的线条粗细进行调整。默认值改为0.2。
[test_ggrepel_options.pdf](https://github.com/YuLab-SMU/enrichplot/files/7072178/test_ggrepel_options.pdf)

