### PR TITLE
Remove suppressMessages() and print() from dotplot.compareClusterResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .RData
 *.DS_Store
 *html
+
+.vscode/
+Rplots*

--- a/R/dotplot.R
+++ b/R/dotplot.R
@@ -180,7 +180,9 @@ dotplot.compareClusterResult <- function(object, x= "Cluster", colorBy="p.adjust
         by2 <- size
     }
       
-    p <- ggplot(df, aes_string(x = x, y = "Description", size = by2))      
+    p <- ggplot(df, aes_string(x = x, y = "Description", size = by2)) +
+        scale_y_discrete(labels = label_func)
+
     if (group) {
         p <- p + geom_line(aes_string(color = "Cluster", group = "Cluster"), size=.3) + 
           ggnewscale::new_scale_colour()     
@@ -195,13 +197,11 @@ dotplot.compareClusterResult <- function(object, x= "Cluster", colorBy="p.adjust
     }  else {
         p <- p +  geom_point(aes_string(color = colorBy)) 
     }  
-    suppressMessages(print(
-        p + scale_color_continuous(low="red", high="blue",
-                        guide=guide_colorbar(reverse=TRUE)) +
-            ylab(NULL) + ggtitle(title) + DOSE::theme_dose(font.size) +
-            scale_size_continuous(range=c(3, 8)) + 
-            scale_y_discrete(labels = label_func) +
-            guides(size  = guide_legend(order = 1), 
-                   color = guide_colorbar(order = 2))
-    ))
+
+    p + scale_color_continuous(low="red", high="blue",
+                    guide=guide_colorbar(reverse=TRUE)) +
+        ylab(NULL) + ggtitle(title) + DOSE::theme_dose(font.size) +
+        scale_size_continuous(range=c(3, 8)) + 
+        guides(size  = guide_legend(order = 1), 
+                color = guide_colorbar(order = 2))
 }


### PR DESCRIPTION
这个 PR 试图解决 #148, #149 中提到的问题。

@huerqiang 在 #99 提到的那个 warning 可以这样复现：

1. 去掉 dotplot.compareClusterResult 中的 `suppressMessages(print(...))` 。
2. 然后运行如下代码：

    ```R
    data(gcSample)
    ck <- compareCluster(geneCluster = gcSample, fun = enrichKEGG)
    dotplot(ck, group=TRUE)
    ```

3. 可以看到如下 warning

    ```
    Scale for 'y' is already present. Adding another scale for 'y', which will replace the existing scale.
    ```

这个 warning 是由 `scale_y_discrete(labels = label_func)` 引起的，但仅在 `group=TRUE` 时出现。知道了问题的诱发点，那么解决方案就很简单了，把 `scale_y_discrete(labels = label_func)` 移动到 `group=TRUE` 功能之前就行了。

不过这里我始终搞不明白，明明 `scale_y_xx` 只出现了一次，会诱发这个 warning ?

另外，Y 叔在 https://github.com/YuLab-SMU/enrichplot/pull/149#issuecomment-968495230 中提到的 `ggnewscale::new_scale_colour` 是有必要的，因为 `geom_point(aes_string(color = colorBy))` 与 `geom_line(aes_string(color = "Cluster", group = "Cluster"), size=.3)` 在 color 上是冲突的。