### PR TITLE
Fix a bug in `goplot`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.15.2.900
+Version: 1.15.2.9001
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.15.2.900
+# enrichplot 1.15.2.9001
 
++ fix a bug in `goplot`: `goplot.gseaResult` need `ontology` slot (2022-2-22, Tue)
 + return `gg` object instead of print it in `dotplot.compareClusterResult()` (2022-01-05, Wed, @altairwei, #160)
 
 # enrichplot 1.15.2

--- a/R/goplot.R
+++ b/R/goplot.R
@@ -41,8 +41,12 @@ goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
     if (!exists(".GOSemSimEnv")) GOSemSim_initial()
     .GOSemSimEnv <- get(".GOSemSimEnv", envir=.GlobalEnv)
     gotbl <- get("gotbl", envir=.GOSemSimEnv)
-
-    GOANCESTOR <- getAncestors(x@ontology)
+    if (class(x) == "gseaResult") {
+        GOANCESTOR <- getAncestors(x@setType)
+    } else {
+        GOANCESTOR <- getAncestors(x@ontology)
+    }
+    
     anc <- AnnotationDbi::mget(id, GOANCESTOR)
     ca <- anc[[1]]
     for (i in 2:length(anc)) {

--- a/R/goplot.R
+++ b/R/goplot.R
@@ -41,7 +41,7 @@ goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
     if (!exists(".GOSemSimEnv")) GOSemSim_initial()
     .GOSemSimEnv <- get(".GOSemSimEnv", envir=.GlobalEnv)
     gotbl <- get("gotbl", envir=.GOSemSimEnv)
-    if (class(x) == "gseaResult") {
+    if (inherits(x， "gseaResult")) {
         GOANCESTOR <- getAncestors(x@setType)
     } else {
         GOANCESTOR <- getAncestors(x@ontology)


### PR DESCRIPTION
Fix the bug in https://github.com/YuLab-SMU/clusterProfiler/issues/434
'goplot' use `ontology` slot to get GOANCESTOR: 
https://github.com/YuLab-SMU/enrichplot/blob/master/R/goplot.R#L45
But the result of `gseGO` only have setType slot:
```r
# line 62 in gseAnalyzer.R
res@setType <- ont
# line 90 in enrichGO.R
res@ontology <- ont
```
So I add this in goplot:
```r
if (class(x) == "gseaResult") {
    GOANCESTOR <- getAncestors(x@setType)
} else {
    GOANCESTOR <- getAncestors(x@ontology)
}
```