### PR TITLE
fix `fc_readable()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.17.1
+Version: 1.17.1.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# enrichplot 1.17.1.991
+
++ fix a bug in `fc_readable()` (2022-08-28, Sun)
+
 # enrichplot 1.17.1
 
 + fix a bug in https://github.com/YuLab-SMU/clusterProfiler/issues/488 (2022-08-25, Thu)

--- a/R/heatplot.R
+++ b/R/heatplot.R
@@ -39,8 +39,8 @@ heatplot.enrichResult <- function(x, showCategory = 30, symbol = "rect", foldCha
 
     n <- update_n(x, showCategory)
     geneSets <- extract_geneSets(x, n)
-
     foldChange <- fc_readable(x, foldChange)
+    pvalue <- fc_readable(x, pvalue)
     d <- list2df(geneSets)
     if (!is.null(foldChange)) {
         d$foldChange <- foldChange[as.character(d[,2])]

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -113,7 +113,7 @@ fc_readable <- function(x, foldChange = NULL) {
     if (is.null(foldChange))
         return(NULL)
 
-    if(x@readable) {
+    if (x@readable && x@keytype != "SYMBOL") {
         gid <- names(foldChange)
         if (is(x, 'gseaResult')) {
             ii <- gid %in% names(x@geneList)


### PR DESCRIPTION
老师，我这次提交是为了修复`fc_readable()`中存在的问题。
 `fc_readable`是用以将`heatplot()`输入的foldChange的name转为`SYMBOL`：
```r
    if (x@readable) {
        gid <- names(foldChange)
        if (is(x, 'gseaResult')) {
            ii <- gid %in% names(x@geneList)
        } else {
            ii <- gid %in% x@gene
        }
        gid[ii] <- x@gene2Symbol[gid[ii]]
        names(foldChange) <- gid
    }
```
但如果用户进行富集分析时输入的基因便是 gene symbol，这时x@readable = TRUE，但x@gene2Symbol是空值，这样foldChange的name就全为空了。因此需要额外加一个判断条件`x@readable && x@keytype != "SYMBOL"`
