### PR TITLE
Cnetplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.17.1.002
+Version: 1.17.1.003
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
-# enrichplot 1.17.1.002
+# enrichplot 1.17.1.003
 
++ change round digits of cnetplot scatterpie legend to 1 (2022_8_29, Mon).
 + fix a bug in `fc_readable()` (2022-08-29, Mon, #189)
 + allows passing `color="NES"` to `dotplot()` for `gseaResult` object (2022-08-29, Mon, #14)
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -351,7 +351,7 @@ cnetplot.compareClusterResult <- function(x,
                 coord_equal()+
                 geom_scatterpie_legend(ID_Cluster_mat2$radius[(n+1):nrow(ID_Cluster_mat2)],
                     x=x_loc, y=y_loc, n = legend_n,
-                    labeller=function(x) round(x*2/(min(sizee))/sqrt(cex_gene),3)) +
+                    labeller=function(x) round(x*2/(min(sizee))/sqrt(cex_gene),1)) +
                 ggplot2::annotate("text", x = x_loc + 3, y = y_loc, label = "log2FC")  +
                 ggplot2::annotate("text", x = x_loc + 3, y = y_loc + 3, label = "gene number")
 


### PR DESCRIPTION
老师，您上午提到的`geom_scatterpie_legend`的小数点问题，我看了一下并不是scatterpie包的问题。在scatterpie里已经对小数进行了很好的处理：
```r
round_digit <- function (d) {
    if (d > 1) {
        round(d)
    } else {
        round(d, -as.integer(floor(log10(abs(d)))))
    }
}
if (length(radius) > n) {
    radius <- unique(sapply(seq(min(radius), max(radius), length.out=n), round_digit))
}
```
而cnetplot之所以会出现很多位的小数点是因为我代码中将logFC的legend label保留了三位小数:
```r
        geom_scatterpie_legend(ID_Cluster_mat2$radius[(n+1):nrow(ID_Cluster_mat2)],
                    x=x_loc, y=y_loc, n = legend_n,
                    labeller=function(x) round(x*2/(min(sizee))/sqrt(cex_gene),3))
```
为了避免极端情况（abs(logFC)全部小于1）我这里将小数点保留了一位。