### PR TITLE
fix `cnetplot()` for `node_label` parameter is flipped

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.19.0.001
+Version: 1.19.0.002
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.19.001
+# enrichplot 1.19.002
 
++ fix `cnetplot()` for `node_label` parameter is flipped(2022_12_4, Sun)
 + bug fixed in `treeplot()`  (2022-11-18, Fri) 
 + enable `dotplot()` and `autofacet()` for `gseaResultList` object
 

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -317,12 +317,12 @@ cnetplot.enrichResult <- function(x,
 
     p <- p + theme_void()
 
-    if (node_label == "category") {       
-        p$data[1:n, "name"] <- NA     
+    if (node_label == "category") { 
+        p$data[-c(1:n), "name"] <- NA          
         p <- add_node_label(p = p, data = NULL, label_size_node = label_size_category,
             cex_label_node = cex_label_category, shadowtext = shadowtext_category)
     } else if (node_label == "gene") {
-        p$data[-c(1:n), "name"] <- NA
+        p$data[1:n, "name"] <- NA 
         p <- add_node_label(p = p, data = NULL, label_size_node = label_size_gene,
             cex_label_node = cex_label_gene, shadowtext = shadowtext_gene)
     } else if (node_label == "all") {


### PR DESCRIPTION
Fix the issue: cnetplot node_label="" option is flipped, when give 'gene', it outputs 'category' label and when give 'category', it labels 'genes' instead.
Examples: 
[test_cnetplot.pdf](https://github.com/YuLab-SMU/enrichplot/files/10148440/test_cnetplot.pdf)
