### PR TITLE
fix `ridgeplot()` for error when x@readable == TRUE and length(x@gene2Symbol) = 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.19.1
+Version: 1.19.1.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# enrichplot 1.19.1
+# enrichplot 1.19.1.991
 
++ fix `ridgeplot` for error when x@readable == TRUE and length(x@gene2Symbol) = 0 (2022-12-5, Mon)
 + fix `cnetplot()` for `node_label` parameter is flipped(2022-12-04, Sun, #216)
 + bug fixed in `treeplot()`  (2022-11-18, Fri) 
 + enable `dotplot()` and `autofacet()` for `gseaResultList` object

--- a/R/ridgeplot.R
+++ b/R/ridgeplot.R
@@ -45,7 +45,7 @@ ridgeplot.gseaResult <- function(x, showCategory=30, fill="p.adjust",
         gs2id <- x@geneSets[x$ID[seq_len(n)]]
     }
 
-    if (x@readable) {
+    if (x@readable && length(x@gene2Symbol) > 0) {
         id <- match(names(x@geneList), names(x@gene2Symbol))
         names(x@geneList) <- x@gene2Symbol[id]
     } 


### PR DESCRIPTION
老师，报错原因是在于 https://github.com/YuLab-SMU/enrichplot/blob/master/R/ridgeplot.R#L49 ， 这里x@gene2Symbol 有可能是个长度为0的character。
出错原因：当用户进行富集分析时，如果输入的keyType = "SYMBOL"，那么x@gene2Symbol就不会被赋值，导致了这个错误。
只有当keyType = "SYMBOL"， 并且进行setReadable处理后，x@gene2Symbol才会被赋值。

