### PR TITLE
Fix when only one cluster result for cnetplot.compareClusterResult

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.21.0
+Version: 1.21.0.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),
@@ -63,4 +63,4 @@ BugReports: https://github.com/GuangchuangYu/enrichplot/issues
 biocViews: Annotation, GeneSetEnrichment, GO, KEGG,
     Pathways, Software, Visualization
 Encoding: UTF-8
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -16,7 +16,7 @@
 ##' @author Guangchuang Yu
 fortify.compareClusterResult <- function(model, data, showCategory=5,
                                          by="geneRatio", split=NULL,
-                                         includeAll=TRUE) {
+                                         includeAll=TRUE, ...) {
     clProf.df <- as.data.frame(model)
     .split <- split
     if ("core_enrichment" %in% colnames(clProf.df)) {

--- a/man/fortify.Rd
+++ b/man/fortify.Rd
@@ -11,7 +11,8 @@
   showCategory = 5,
   by = "geneRatio",
   split = NULL,
-  includeAll = TRUE
+  includeAll = TRUE,
+  ...
 )
 
 \method{fortify}{enrichResult}(
@@ -38,11 +39,11 @@
 
 \item{includeAll}{logical}
 
+\item{...}{additional parameter}
+
 \item{order}{logical}
 
 \item{drop}{logical}
-
-\item{...}{additional parameter}
 }
 \value{
 data.frame


### PR DESCRIPTION
老师，之前cnetplot.compareClusterResult没有考虑到只有一个cluster有显著结果的情况，会出现图中没有节点的问题：
![1723b2a507c2dabf9b5db71eb0ddb6f](https://github.com/YuLab-SMU/enrichplot/assets/48857018/d92db522-25b4-4cea-9572-f0e09bd9c3f2)
此次提交进行了修复：
![image](https://github.com/YuLab-SMU/enrichplot/assets/48857018/dfdb8c89-77fe-46ed-974d-7da2bca70af9)
